### PR TITLE
Document charm creation and deployment to staging

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -90,6 +90,7 @@ juju
 KeyError
 kubeconfig
 labelled
+lifecycle
 Lastpass
 LDAP
 learnt

--- a/engineering-practices/charm-development/charm-creation.md
+++ b/engineering-practices/charm-development/charm-creation.md
@@ -13,7 +13,7 @@ This how-to will not cover implementation details.
 
 2. Create the GitHub repository
 
-   Follow the instructions from [How to maintain your repository settings as code](maintain-repo-settings-as-code).
+   Follow the instructions from [How to maintain your repository settings as code](/engineering-practices/how-to/maintain-repo-settings-as-code).
 
 3. Register the charm name in Charmhub
 

--- a/engineering-practices/charm-development/charm-deployment-to-staging.md
+++ b/engineering-practices/charm-development/charm-deployment-to-staging.md
@@ -1,0 +1,19 @@
+# Charm deployment to staging
+
+
+## Request the environment 
+
+Request a staging environement on [IS Portal](https://portal.admin.canonical.com/requests/new).
+  - Use the "IS-Services: Set up a new ProdStack environment" category.
+  - Service name: provide an explicit name, you don't have to prefix it with "stg"
+  - Team/owner: is-charms
+  - Cloud: PS6
+
+
+## Access the environment
+
+Once the environment has been created, you should be able to access the environment through the bastions (see [how-tos](/engineering-practices/how-to) if needed).
+
+## Enable Gitops
+
+The process is described in [IS ReadTheDoc site](https://canonical-information-systems-documentation.readthedocs-hosted.com/en/latest/products/devopsenv/how-to/gitops-manage-existing-model/).

--- a/engineering-practices/charm-development/charm-deployment-to-staging.md
+++ b/engineering-practices/charm-development/charm-deployment-to-staging.md
@@ -12,7 +12,7 @@ Request a staging environement on [IS Portal](https://portal.admin.canonical.com
 
 ## Access the environment
 
-Once the environment has been created, you should be able to access the environment through the bastions (see [how-tos](/engineering-practices/how-to) if needed).
+Once the environment has been created, you should be able to access the environment through the bastions (see [how-tos](/engineering-practices/how-to/index) if needed).
 
 ## Enable Gitops
 

--- a/engineering-practices/charm-development/charm-deployment-to-staging.md
+++ b/engineering-practices/charm-development/charm-deployment-to-staging.md
@@ -1,6 +1,5 @@
 # Charm deployment to staging
 
-
 ## Request the environment 
 
 Request a staging environment on [IS Portal](https://portal.admin.canonical.com/requests/new).
@@ -13,6 +12,7 @@ Request a staging environment on [IS Portal](https://portal.admin.canonical.com/
 ## Access the environment
 
 Once the environment has been created, you should be able to access the environment through the bastions.
+
 
 ## Enable GitOps
 

--- a/engineering-practices/charm-development/charm-deployment-to-staging.md
+++ b/engineering-practices/charm-development/charm-deployment-to-staging.md
@@ -4,7 +4,7 @@
 
 Request a staging environment on [IS Portal](https://portal.admin.canonical.com/requests/new).
   - Use the "IS-Services: Set up a new Prodstack environment" category.
-  - Service name: provide an explicit name, you don't have to prefix it with "stg"
+  - Service name: provide an explicit name. You don't have to prefix the name with "stg".
   - Team/owner: is-charms
   - Cloud: PS6
 

--- a/engineering-practices/charm-development/charm-deployment-to-staging.md
+++ b/engineering-practices/charm-development/charm-deployment-to-staging.md
@@ -1,5 +1,10 @@
 # Charm deployment to staging
 
+This page aims at listing the main steps to deploy one of our charms in staging.
+
+It's not exhaustive yet, feel free to add missing sections.
+
+
 ## Request the environment 
 
 Request a staging environment on [IS Portal](https://portal.admin.canonical.com/requests/new).

--- a/engineering-practices/charm-development/charm-deployment-to-staging.md
+++ b/engineering-practices/charm-development/charm-deployment-to-staging.md
@@ -2,7 +2,9 @@
 
 This page aims at listing the main steps to deploy one of our charms in staging.
 
-It's not exhaustive yet, feel free to add missing sections.
+```{warning}
+This page is a work in progress. Feel free to add missing sections.
+```
 
 
 ## Request the environment 

--- a/engineering-practices/charm-development/charm-deployment-to-staging.md
+++ b/engineering-practices/charm-development/charm-deployment-to-staging.md
@@ -3,8 +3,8 @@
 
 ## Request the environment 
 
-Request a staging environement on [IS Portal](https://portal.admin.canonical.com/requests/new).
-  - Use the "IS-Services: Set up a new ProdStack environment" category.
+Request a staging environment on [IS Portal](https://portal.admin.canonical.com/requests/new).
+  - Use the "IS-Services: Set up a new Prodstack environment" category.
   - Service name: provide an explicit name, you don't have to prefix it with "stg"
   - Team/owner: is-charms
   - Cloud: PS6
@@ -12,8 +12,8 @@ Request a staging environement on [IS Portal](https://portal.admin.canonical.com
 
 ## Access the environment
 
-Once the environment has been created, you should be able to access the environment through the bastions (see [how-tos](/engineering-practices/how-to/index) if needed).
+Once the environment has been created, you should be able to access the environment through the bastions.
 
-## Enable Gitops
+## Enable GitOps
 
-The process is described in [IS ReadTheDoc site](https://canonical-information-systems-documentation.readthedocs-hosted.com/en/latest/products/devopsenv/how-to/gitops-manage-existing-model/).
+The process is described in [IS documentation](https://canonical-information-systems-documentation.readthedocs-hosted.com/en/latest/products/devopsenv/how-to/gitops-manage-existing-model/).

--- a/engineering-practices/charm-development/index.rst
+++ b/engineering-practices/charm-development/index.rst
@@ -1,9 +1,12 @@
-Implementation
-==============
+Charm development
+=================
+
+You'll find here the documentation related to each phase of the charm lifecycle.
 
 .. toctree::
    :maxdepth: 1
 
    Charm creation <charm-creation>
+   Charm deployment to staging <charm-deployment-to-staging>
    Service Health Guidance <service-health-guidance/index>
 

--- a/engineering-practices/charm-development/index.rst
+++ b/engineering-practices/charm-development/index.rst
@@ -4,5 +4,6 @@ Implementation
 .. toctree::
    :maxdepth: 1
 
+   Charm creation <charm-creation>
    Service Health Guidance <service-health-guidance/index>
 

--- a/engineering-practices/how-to/index.rst
+++ b/engineering-practices/how-to/index.rst
@@ -9,7 +9,6 @@ How-to guides
    Add a repository to the Mattermost GitHub bot <add-repo-mattermost-github-bot>
    Configure a terraform plan on the IS-charms bastion <configure-terraform-plan-bastion>
    Connect your pull request to a Jira ticket <connect-a-pr-to-jira>
-   Create a new charm <create-new-charm>
    Deploy Synapse locally with with production terraform plans <local-synapse-deployed-with-production-terraform-plans>
    Estimate Discourse downtime during a charm upgrade <estimate-discourse-downtime-during-charm-upgrades>
    Fix "Gateway Address Unavailable" error <fix-gateway-address-unavailable-traefik-ps6>


### PR DESCRIPTION
### Overview

The goal is to increase discoverability of the documention by grouping it by entity we are working on. 

### Rationale

Charm lifecycle's documentation is spread in different places and we have some gaps. Here we're moving the how-to that is describing the creation of a new charm to the corresponding phase in "Charm development" and we're starting to document the "Staging deployment".

### Checklist
- [x] Changes were previewed locally with `make run`.
- [x] Spelling and link checkers were run locally.
- [x] The Technical Author is tagged as a reviewer.
- [x] If the content is technical, an additional reviewer has been tagged.

<!-- Explanation for any unchecked items above -->