### PR TITLE
Rename charm template

### DIFF
--- a/delivery-practices/pull-requests/index.rst
+++ b/delivery-practices/pull-requests/index.rst
@@ -189,5 +189,5 @@ such as enabling a new bot), the PR description should include:
     * Or which of the standards/ guidelines was not applied and why
 
 The above should be created as a
-`template <https://github.com/canonical/is-charms-template-repo/blob/main/.github/pull_request_template.yaml>`_
+`template <https://github.com/canonical/platform-engineering-charm-template/blob/main/.github/pull_request_template.yaml>`_
 for raising PRs across all of our repositories.

--- a/engineering-practices/documentation/readme-guidance.rst
+++ b/engineering-practices/documentation/readme-guidance.rst
@@ -8,8 +8,8 @@ project and links to relevant resources (especially documentation).
 The README template
 ~~~~~~~~~~~~~~~~~~~
 
-If you create a new charm using the ``is-charms-template-repo``, then your new
-repository will contain the `README template <https://github.com/canonical/is-charms-template-repo/blob/main/README.md>`_
+If you create a new charm using the ``platform-engineering-charm-template``, then your new
+repository will contain the `README template <https://github.com/canonical/platform-engineering-charm-template/blob/main/README.md>`_
 that you can use as guidance.
 
 Pre-existing charms that were created prior to the inclusion of this template

--- a/engineering-practices/how-to/maintain-repo-settings-as-code.md
+++ b/engineering-practices/how-to/maintain-repo-settings-as-code.md
@@ -9,10 +9,10 @@ Please follow the steps below to apply the changes.
 
 ## Create a new repository
 
-For a new charm, create your repository using the "canonical/is-charms-template-repo" template:
+For a new charm, create your repository using the "canonical/platform-engineering-charm-template" template:
 
 1. Go to [New repository](https://github.com/new).
-2. Select "canonical/is-charms-template-repo" as the template in the drop-down.
+2. Select "canonical/platform-engineering-charm-template" as the template in the drop-down.
 3. The charm should most likely be public.
 4. "Codecov", "Jira Software + Github" and "Renovate" should be enabled.
 


### PR DESCRIPTION
### Overview

Maintenance

### Rationale

is-charms-template repo has been renamed to platform-engineering-charm-template.

### Checklist
- [x] Changes were previewed locally with `make run`.
- [x] Spelling and link checkers were run locally.
- [x] The Technical Author is tagged as a reviewer.
- [x] If the content is technical, an additional reviewer has been tagged.

<!-- Explanation for any unchecked items above -->